### PR TITLE
:arrow_up: Update runner in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: "Release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
         uses: actions/checkout@v3


### PR DESCRIPTION
The runner ubuntu-18.04 is no longer available.

As the version is not really important, run this workflow on ubuntu-latest.